### PR TITLE
Choose a completion plugin + other vimrc todos

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -41,6 +41,8 @@ if empty($SSH_CONNECTION)
    endif
 endif
 
+" let mapleader = "\<space>"
+
 "" Filetype + syntax
 " filetype plugin indent on
 " syntax enable
@@ -81,7 +83,10 @@ Plug 'tpope/vim-unimpaired'
 if exists('s:csapprox_needed')
 Plug 'godlygeek/csapprox'
 endif
-Plug 'SirVer/ultisnips'
+Plug 'ajh17/VimCompletesMe'
+" Plug 'Shougo/neocomplete.vim'
+" Plug 'Shougo/deoplete.nvim'
+" Plug 'SirVer/ultisnips'
 Plug 'honza/vim-snippets'
 Plug 'bfredl/nvim-miniyank', has('nvim') ? {} : { 'on': [] }
 if $TERM !~ 'linux' " disable in the vconsole
@@ -107,6 +112,8 @@ let did_install_default_menus = 1
 " TODO: separate function, to emulate vf()
 command! -nargs=+ VF call fzf#run(fzf#vim#wrap({'source': 'locate -0 / | grep -zv "/\.\(git\|svn\|hg\)\(/\|$\)\|~$"', 'options': '--read0 -0 -1 -m -q"'.<q-args>.'" --prompt "VF> "'}))
 nmap <s-space> :VF<space>
+
+" call deoplete#enable()
 
 let g:UltiSnipsEnableSnipMate      = 0
 let g:UltiSnipsSnippetsDir         = s:vim.'/ulti_snippets/'

--- a/.vimrc
+++ b/.vimrc
@@ -102,6 +102,7 @@ Plug 'terceiro/vim-foswiki'
 Plug 'vim-scripts/nginx.vim'
 Plug 'vim-scripts/iptables'
 Plug 'pearofducks/ansible-vim'
+Plug 'jeetsukumaran/vim-filebeagle'
 Plug 'junegunn/vim-easy-align'
 Plug 'junegunn/fzf', { 'dir': '~/.fzf', 'do': './install --all' }
 Plug 'junegunn/fzf.vim'


### PR DESCRIPTION
- [ ] fork / improve VimCompletesMe
- [ ] new ultisnips trigger (if using a `<tab>` completion plugin)
- [ ] special map for `^x^p`?
- [ ] use `<space>` vs `\` as a map leader (implies changing `nnoremap <space> <c-^>`)
- [ ] `<g-space>` to switch to alternate file
- [ ] create a map for `:e ~/` (remove space?) (and `:e`)
- [x] `c23` - change the column indicator from `c` to ...
- [ ] use a netrw alternative so I can bookmark a directory (`~/help`, `~/repos`, ...)
- [ ] review autocommands (81 column)
- [ ] auto save?
- [ ] auto format to 80 chars. test/review
- [ ] spell check commands? (`:FR`...)
- [ ] raise issue in https://github.com/tpope/vim-commentary regarding gcc with #bla ... # second comment
- [ ] `let @/ = 'test'` and yet _test_ isn't listed in `q/`